### PR TITLE
NR-1564 Add Support For Static Url and Update Relative Path to Embed.js

### DIFF
--- a/inc/class-talk-settings-page.php
+++ b/inc/class-talk-settings-page.php
@@ -53,7 +53,19 @@ class Talk_Settings_Page {
 		);
 		register_setting( 'talk-settings', 'coral_talk_base_url', array(
 			'type' => 'string',
-			'sanitize_callback' => array( $this, 'sanitize_base_url' ),
+			'sanitize_callback' => array( $this, 'sanitize_url' ),
+		) );
+
+		add_settings_field(
+			'coral_talk_static_url',
+			__( 'Talk Static Asset URL', 'coral-project-talk' ),
+			array( $this, 'render_static_url_field' ),
+			'talk-settings',
+			'about-talk'
+		);
+		register_setting( 'talk-settings', 'coral_talk_static_url', array(
+			'type' => 'string',
+			'sanitize_callback' => array( $this, 'sanitize_url' ),
 		) );
 
 		add_settings_field(
@@ -73,7 +85,7 @@ class Talk_Settings_Page {
 	 * @return String Sanitized and untrailingslashed URL.
 	 * @since 0.0.6
 	 */
-	public function sanitize_base_url( $url ) {
+	public function sanitize_url( $url ) {
 		return esc_url( untrailingslashit( $url ) );
 	}
 
@@ -91,6 +103,24 @@ class Talk_Settings_Page {
 			id="coral_talk_base_url"
 			type="url"
 			value="<?php echo esc_url( get_option( 'coral_talk_base_url' ) ); ?>"
+		/>
+		<?php
+	}
+
+	/**
+	 * Prints input field for static url setting.
+	 *
+	 * @since 0.1.0
+	 */
+	public function render_static_url_field() {
+		?>
+		<input
+				style="width: 600px; height: 40px;"
+				name="coral_talk_static_url"
+				placeholder="https://cdn.talk-assets.com"
+				id="coral_talk_static_url"
+				type="url"
+				value="<?php echo esc_url( get_option( 'coral_talk_static_url' ) ); ?>"
 		/>
 		<?php
 	}

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -15,8 +15,8 @@ $div_id = 'coral_talk_' . absint( rand() );
 if ( ! empty( $talk_url ) ) : ?>
 	<div class="<?php echo esc_attr( $talk_container_classes ); ?>" id="<?php echo esc_attr( $div_id ); ?>"></div>
 	<script src="<?php echo esc_url( $static_url . '/static/embed.js' ); ?>" async onload="
-		Coral.static_url = '<?php echo esc_url( $static_url ) ?>';
-		Coral.talk_url = '<?php echo esc_url($talk_url ) ?>';
+		Coral.static_url = '<?php echo esc_url( $static_url ); ?>';
+		Coral.talk_url = '<?php echo esc_url( $talk_url ); ?>';
 		Coral.talkStream = Coral.Talk.render(document.getElementById('<?php echo esc_js( $div_id ); ?>'), {
 			talk: '<?php echo esc_url( $talk_url ); ?>'
 		});

--- a/inc/comments-template.php
+++ b/inc/comments-template.php
@@ -9,11 +9,14 @@
  */
 
 $talk_url = get_option( 'coral_talk_base_url' );
+$static_url = get_option( 'coral_talk_static_url', $talk_url );
 $talk_container_classes = get_option( 'coral_talk_container_classes' );
 $div_id = 'coral_talk_' . absint( rand() );
 if ( ! empty( $talk_url ) ) : ?>
 	<div class="<?php echo esc_attr( $talk_container_classes ); ?>" id="<?php echo esc_attr( $div_id ); ?>"></div>
-	<script src="<?php echo esc_url( $talk_url . '/embed.js' ); ?>" async onload="
+	<script src="<?php echo esc_url( $static_url . '/static/embed.js' ); ?>" async onload="
+		Coral.static_url = '<?php echo esc_url( $static_url ) ?>';
+		Coral.talk_url = '<?php echo esc_url($talk_url ) ?>';
 		Coral.talkStream = Coral.Talk.render(document.getElementById('<?php echo esc_js( $div_id ); ?>'), {
 			talk: '<?php echo esc_url( $talk_url ); ?>'
 		});

--- a/talk.php
+++ b/talk.php
@@ -3,7 +3,7 @@
  * Plugin Name: Coral Project Talk
  * Plugin URI: https://coralproject.net
  * Description: A plugin to replace stock WP commenting with Talk from the Coral Project
- * Version: 0.0.6
+ * Version: 0.1.0
  * Author: Alley Interactive, The Coral Project
  * Author URI: https://www.alleyinteractive.com
  * License: Apache 2.0


### PR DESCRIPTION
The static url option allows the WP Admin to set the root url of static talk assets to something other than the url of the Talk app. The static url option value will be used if it's available. This logic follows the same logic used in the [Talk source](https://github.com/coralproject/talk/blob/master/config.js#L179).

Talk v4 has also updated where [static assets live](https://github.com/coralproject/talk/blob/master/routes/index.js#L38) by default. The path has been updated to be compatible.